### PR TITLE
🎨 style(digital-business-cards.js): add width: 100% to the container …

### DIFF
--- a/digital-business-cards.js
+++ b/digital-business-cards.js
@@ -161,6 +161,7 @@ template.innerHTML = `
       flex-wrap: wrap;
       justify-content: space-evenly;
       margin-top: 16px;
+      width: 100%;
     }
     .social-media-container a {
       margin: 10px 4px;
@@ -405,7 +406,7 @@ class DigitalBusinessCard extends HTMLElement {
             socialMediaLinks.forEach((linkObj) => {
                 const platform = linkObj.platform;
                 const url = linkObj.url;
-                const icon = socialMediaIcons[platform]; // Assuming socialMediaIcons is defined elsewhere
+                const icon = socialMediaIcons[platform];
 
                 if (icon) {
                     const anchor = document.createElement("a");


### PR DESCRIPTION
…to ensure it takes up the full width of its parent

🐛 fix(digital-business-cards.js): remove unnecessary comment about socialMediaIcons being defined elsewhere